### PR TITLE
Add a notice to open the demo in a new tab

### DIFF
--- a/demos/src/demo.js
+++ b/demos/src/demo.js
@@ -3,7 +3,13 @@ import './../../main.js';
 
 function initDemos() {
 	document.addEventListener('DOMContentLoaded', function() {
+
+		if (window.self === window.top) {
+			document.querySelector('.demo-notice').remove();
+		}
+
 		document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
+
 	});
 }
 

--- a/demos/src/demo.mustache
+++ b/demos/src/demo.mustache
@@ -1,3 +1,7 @@
+<div class='demo-notice'>
+	Open this demo in a new tab to see scrolling behaviour
+</div>
+
 <div class="section o-grid-row">
 	<div data-o-grid-colspan="hide M3">
 		<nav data-o-component='o-in-page-nav'>

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -24,5 +24,5 @@ nav a {
 	font-size: 20px;
 	padding: 20px;
 	text-align: center;
-	margin-bottom: 30px
+	margin-bottom: 30px;
 }

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -18,3 +18,11 @@ nav a {
 .o-in-page-nav-item--active {
 	font-weight: bold;
 }
+
+.demo-notice {
+	background-color: #cccccc;
+	font-size: 20px;
+	padding: 20px;
+	text-align: center;
+	margin-bottom: 30px
+}


### PR DESCRIPTION
The demo doesn't work in the registry, because of it being shown in
an iframe. This commit adds a notice to the user to open the demo in a
new tab.